### PR TITLE
Added optional prefix to cache key

### DIFF
--- a/src/main/java/com/keithbranton/mojo/Html2jsMojo.java
+++ b/src/main/java/com/keithbranton/mojo/Html2jsMojo.java
@@ -49,6 +49,12 @@ public class Html2jsMojo extends AbstractMojo {
 	private String include;
 
 	/**
+	 * Prefix to put before the cache key
+	 */
+	@Parameter(defaultValue = "")
+	private String prefix;	
+	
+	/**
 	 * Comma separated list of patterns to identify files to be ignored
 	 */
 	@Parameter
@@ -188,13 +194,13 @@ public class Html2jsMojo extends AbstractMojo {
 		lines.add("angular.module('templates-main', ['" + Joiner.on("', '").join(Lists.transform(files, new Function<File, String>() {
 			@Override
 			public String apply(final File file) {
-				return file.getAbsolutePath().replace(sourceDir.getAbsolutePath(), "");
+				return prefix + file.getAbsolutePath().replace(sourceDir.getAbsolutePath(), "");
 			}
 		})) + "']);");
 		lines.add("");
 
 		for (final File file : files) {
-			String shortName = file.getAbsolutePath().replace(sourceDir.getAbsolutePath(), "");
+			String shortName = prefix + file.getAbsolutePath().replace(sourceDir.getAbsolutePath(), "");
 			lines.add("angular.module('" + shortName + "', []).run(['$templateCache', function($templateCache) {");
 
 			List<String> fileLines = null;


### PR DESCRIPTION
Hi,

I use a workflow where during templates are loaded individually as html, and they're only packaged using html2js in release mode. For reasons specific to my setting, the template urls are also relative. To make it possible to add cache keys without the leading "/" (i.e. similar to relative url) during html2js I had to add an optional custom prefix that gets added to the cache key.

Not sure if this makes sense for anyone else but here it is.
